### PR TITLE
Mark own shouts

### DIFF
--- a/public/js/lib/utils.js
+++ b/public/js/lib/utils.js
@@ -25,6 +25,7 @@
 		},
 		parseShout: function(shout, onlyText) {
 			var tpl = onlyText ? textTpl : shoutTpl;
+			shout.ownShout = shout.fromuid === app.user.uid;
 			shout.user.hasRights = shout.fromuid === app.uid || app.isAdmin === true;
 			return window.templates.parse(tpl, shout);
 		},

--- a/templates/shoutbox/shout.tpl
+++ b/templates/shoutbox/shout.tpl
@@ -1,4 +1,4 @@
-<div data-uid="{fromuid}" class="shoutbox-shout-container">
+<div data-uid="{fromuid}" class="shoutbox-shout-container <!-- IF ownShout -->ownShout<!-- ENDIF ownShout -->">
     <a class="shoutbox-shout-avatar-link {user.status}" href="/user/{user.userslug}">
         <img class="shoutbox-shout-avatar" title="{user.username}" src="{user.picture}"/>
         <div class="shoutbox-shout-avatar-overlay">


### PR DESCRIPTION
This adds an `ownShout` class to the shout container, so you can style own shouts differently.  
I used it to create this (totally not facebook inspired) chat:  
![bildschirmfoto 2015-04-21 um 19 53 10](https://cloud.githubusercontent.com/assets/6115429/7258945/13df2158-e860-11e4-82c0-da33d9ae4e62.png)
